### PR TITLE
Fix spellcheck workflow cache failures

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,16 +7,16 @@ on:
   pull_request:
 
 env:
-  node_version: 16
+  node_version: 18
 
 jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          cache: yarn
           node-version: ${{ env.node_version }}
+          cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn spell-check

--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,10 @@
     "language": "en",
     "words": [
         "abigen",
+        "Danksharding",
+        "EIPs",
+        "MCOPY",
+        "SELFDESTRUCT",
         "alloc",
         "avascan",
         "avax",


### PR DESCRIPTION
## Summary

Fixes the spellcheck CI workflow which is failing with cache service 400 errors.

## Changes

| Component | Before | After |
|-----------|--------|-------|
| `actions/checkout` | v2 | **v4** |
| `actions/setup-node` | v2 | **v4** |
| Node.js | 16 (EOL) | **18** (LTS) |

This is the same fix applied to `ci.yml` in PR #16, now applied to `spellcheck.yml`.

---

🤖 Generated with [Claude Code](https://claude.ai/code)